### PR TITLE
Add Ability to Prepare Login with Custom State

### DIFF
--- a/src/OidcClient/AuthorizeClient.cs
+++ b/src/OidcClient/AuthorizeClient.cs
@@ -85,24 +85,24 @@ namespace IdentityModel.OidcClient
             return await _options.Browser.InvokeAsync(browserOptions, cancellationToken);
         }
 
-        public AuthorizeState CreateAuthorizeState(Parameters frontChannelParameters)
+        public AuthorizeState CreateAuthorizeState(Parameters frontChannelParameters, string customState = null)
         {
             _logger.LogTrace("CreateAuthorizeStateAsync");
 
             var pkce = _crypto.CreatePkceData();
 
-            var state = new AuthorizeState
+            var authorizeState = new AuthorizeState
             {
-                State = _crypto.CreateState(_options.StateLength),
+                State = customState ?? _crypto.CreateState(_options.StateLength),
                 RedirectUri = _options.RedirectUri,
                 CodeVerifier = pkce.CodeVerifier,
             };
 
-            state.StartUrl = CreateAuthorizeUrl(state.State, pkce.CodeChallenge, frontChannelParameters);
+            authorizeState.StartUrl = CreateAuthorizeUrl(authorizeState.State, pkce.CodeChallenge, frontChannelParameters);
 
-            _logger.LogDebug(LogSerializer.Serialize(state));
+            _logger.LogDebug(LogSerializer.Serialize(authorizeState));
 
-            return state;
+            return authorizeState;
         }
 
         internal string CreateAuthorizeUrl(string state, string codeChallenge,

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -101,15 +101,16 @@ namespace IdentityModel.OidcClient
         /// <summary>
         /// Prepares the login request.
         /// </summary>
-        /// <param name="frontChannelParameters">extra parameters to send to the authorize endpoint.</param>
-        /// /// <param name="cancellationToken">A token that can be used to cancel the request</param>
+        /// <param name="frontChannelParameters">Extra parameters to send to the authorize endpoint.</param>
+        /// <param name="cancellationToken">A token that can be used to cancel the request</param>
+        /// <param name="customState">Custom state string to override the generated value</param>
         /// <returns>State for initiating the authorize request and processing the response</returns>
-        public virtual async Task<AuthorizeState> PrepareLoginAsync(Parameters frontChannelParameters = null, CancellationToken cancellationToken = default)
+        public virtual async Task<AuthorizeState> PrepareLoginAsync(Parameters frontChannelParameters = null, CancellationToken cancellationToken = default, string customState = null)
         {
             _logger.LogTrace("PrepareLoginAsync");
 
             await EnsureConfigurationAsync(cancellationToken);
-            return _authorizeClient.CreateAuthorizeState(frontChannelParameters);
+            return _authorizeClient.CreateAuthorizeState(frontChannelParameters, customState);
         }
 
         /// <summary>


### PR DESCRIPTION
- PrepareLoginAysnc now takes a optional `customState` string which will override the value generated by `crypto.CreatedState`

CoAuthored by @dpbackes

Implements Issue #339 

Questions:

- Would you like me to add some additional tests?
- Any issue with adding `customState` parameter to `PrepareLoginAysnc`? I could split it into another method if your prefer.